### PR TITLE
DEVOPS-3979: Add License service URL to CMS config

### DIFF
--- a/examples/services.pp
+++ b/examples/services.pp
@@ -51,4 +51,5 @@ class { '::tic::services':
   zipkin_kafka_servers                     => 'localhost:9999',
   zipkin_sampling_rate                     => '0.3',
   webhooks_external_url                    => 'webhook-test-url',
+  license_service_url                      => 'http://license-management-node',
 }

--- a/manifests/services.pp
+++ b/manifests/services.pp
@@ -208,6 +208,7 @@ class tic::services (
   $scim_service_url       = undef,
   $crypto_service_url     = undef,
   $config_service_url     = undef,
+  $license_service_url    = undef,
 
   $zipkin_enabled       = undef,
   $zipkin_kafka_topic   = undef,

--- a/manifests/services/config.pp
+++ b/manifests/services/config.pp
@@ -96,6 +96,12 @@ class tic::services::config {
         'zipkin.sampler.percentage'     => $tic::services::params::zipkin_sampling_rate,
       };
 
+    'cms_service':
+      path     => "${config_dir}/org.talend.ipaas.rt.cms.cfg",
+      settings => {
+        'license-management.url' => $tic::services::params::license_service_url,
+      };
+
   }
 
   if 'tipaas-tpsvc-crypto-client' in $features {

--- a/manifests/services/params.pp
+++ b/manifests/services/params.pp
@@ -32,6 +32,11 @@ class tic::services::params {
   $postgres_nodes           = pick($tic::services::postgres_nodes,           'localhost')
   $zookeeper_nodes          = pick($tic::services::zookeeper_nodes,          'localhost')
   $mongo_nodes              = pick($tic::services::mongo_nodes,              'localhost')
+  $iam_service_node         = pick($tic::services::iam_service_node,         'localhost')
+  $scim_service_node        = pick($tic::services::scim_service_node,        'localhost')
+  $crypto_service_node      = pick($tic::services::crypto_service_node,      'localhost')
+  $license_service_node     = pick($tic::services::license_service_node,     'localhost')
+
 
   $postgres_db_host    = pick($postgres_nodes,  'localhost')
 
@@ -224,14 +229,11 @@ class tic::services::params {
   $dispatcher_input_queue    = pick($tic::services::dispatcher_input_queue,    'ipaas.talend.dispatcher.input.queue')
   $dispatcher_response_queue = pick($tic::services::dispatcher_response_queue, 'ipaas.talend.dispatcher.response.queue')
 
-  $iam_service_node       = pick($tic::services::iam_service_node, 'localhost')
-  $scim_service_node      = pick($tic::services::scim_service_node, 'localhost')
-  $crypto_service         = pick($tic::services::crypto_service_node, 'localhost')
-
   $iam_service_url        = pick($tic::services::iam_service_url, "http://${iam_service_node}")
   $scim_service_url       = pick($tic::services::scim_service_url, "http://${scim_service_node}")
   $crypto_service_url     = pick($tic::services::crypto_service_url, "http://${crypto_service_node}")
-  $config_service_url     = pick($tic::services::config_service_url, "http://${config_service_url}")
+  $config_service_url     = pick($tic::services::config_service_url, "http://${config_service_node}")
+  $license_service_url    = pick($tic::services::license_service_url, "http://${license_service_node}")
 
   $zipkin_enabled       = pick($tic::services::zipkin_enabled,       false)
   $zipkin_kafka_topic   = pick($tic::services::zipkin_kafka_topic,   'unconfigured')

--- a/spec/acceptance/services_spec.rb
+++ b/spec/acceptance/services_spec.rb
@@ -91,6 +91,10 @@ describe 'services' do
     its(:content) { should include 'webhooks.service.url=webhook-test-url' }
   end
 
+  describe file('/opt/talend/ipaas/rt-infra/etc/org.talend.ipaas.rt.cms.cfg') do
+    its(:content) { should include 'license-management.url = http://license-management-node' }
+  end
+
   describe file('/opt/talend/ipaas/rt-infra/bin/karaf.service') do
     its(:content) { should_not include 'WantedBy=default.target' }
   end


### PR DESCRIPTION
Tested by local test run.
Services params manifest has been reorganized a little.