### PR TITLE
TMC-20283: Remove gc.log limitation since manage by logrotate now

### DIFF
--- a/manifests/frontend/install.pp
+++ b/manifests/frontend/install.pp
@@ -25,7 +25,6 @@ class tic::frontend::install {
       '-Xloggc:/srv/tomcat/ipaas-srv/logs/gc.log',
       '-XX:+UseGCLogFileRotation',
       '-XX:NumberOfGCLogFiles=1',
-      '-XX:GCLogFileSize=10M',
     ]
   }
 


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**

Logrotation managed from logrotate, java parameters is doing the same action, this need to be corrected

**What is the chosen solution to this problem?**
Remove file limit for gc.log and let Logrotation managed it.

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TMC-20283

**Please check if the Pull Request fulfills these requirements**
- [+ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [-] Tests for the changes have been added (for bug fixes / features)
- [-] Docs have been added / updated (for bug fixes / features)
- [-] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->

**[ ] This Pull Request introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
