### PR TITLE
DEVOPS-8808 Add webhooks_postgres config

### DIFF
--- a/manifests/services.pp
+++ b/manifests/services.pp
@@ -170,10 +170,12 @@ class tic::services (
   $confirm_email_external_url  = undef,
   $tipaas_email_subject        = undef,
 
-  $webhooks_url           = undef,
-  $webhooks_external_url  = undef,
-  $webhooks_redis_host    = undef,
-  $webhooks_redis_port    = undef,
+  $webhooks_url               = undef,
+  $webhooks_external_url      = undef,
+  $webhooks_redis_host        = undef,
+  $webhooks_redis_port        = undef,
+  $webhooks_postgres_server   = undef,
+  $webhooks_postgres_password = undef,
 
   $redis_cache_host      = undef,
   $redis_cache_port      = undef,

--- a/manifests/services/config.pp
+++ b/manifests/services/config.pp
@@ -45,6 +45,15 @@ class tic::services::config {
         'log.messages' => $tic::services::params::log_amq_messages,
       };
 
+    'webhooks_datasource':
+      path     => "${config_dir}/org.talend.ipaas.rt.webhooks.datasource.cfg",
+      settings => {
+        'datasource.servername'   => $tic::services::params::webhooks_postgres_server,
+        'datasource.username'     => 'webhooks',
+        'datasource.databasename' => 'webhooks',
+        'datasource.password'     => $tic::services::params::webhooks_postgres_password,
+      };
+
     'ams_datasource':
       path     => "${config_dir}/org.talend.ipaas.rt.ams.datasource.cfg",
       settings => {

--- a/manifests/services/params.pp
+++ b/manifests/services/params.pp
@@ -191,10 +191,12 @@ class tic::services::params {
   $confirm_email_external_url  = pick($tic::services::confirm_email_external_url,  'https://integrationcloud.talend.com/#/signup/login?trialKey=')
   $tipaas_email_subject        = pick($tic::services::tipaas_email_subject,        'Talend Integration Cloud Evaluation: Confirmation')
 
-  $webhooks_url           = pick($tic::services::webhooks_url,           'unconfigured')
-  $webhooks_external_url  = pick($tic::services::webhooks_external_url,  'unconfigured')
-  $webhooks_redis_host    = pick($tic::services::webhooks_redis_host,    'unconfigured')
-  $webhooks_redis_port    = pick($tic::services::webhooks_redis_port,    6379)
+  $webhooks_url               = pick($tic::services::webhooks_url,               'unconfigured')
+  $webhooks_external_url      = pick($tic::services::webhooks_external_url,      'unconfigured')
+  $webhooks_redis_host        = pick($tic::services::webhooks_redis_host,        'unconfigured')
+  $webhooks_redis_port        = pick($tic::services::webhooks_redis_port,        6379)
+  $webhooks_postgres_server   = pick($tic::services::webhooks_postgres_server,   $postgres_db_host)
+  $webhooks_postgres_password = pick($tic::services::webhooks_postgres_password, 'missing')
 
   $redis_cache_host   = pick($tic::services::redis_cache_host, 'unconfigured')
   $redis_cache_port   = pick($tic::services::redis_cache_port, 6379)

--- a/spec/acceptance/services_spec.rb
+++ b/spec/acceptance/services_spec.rb
@@ -77,8 +77,7 @@ describe 'services' do
   end
 
   describe file('/opt/talend/ipaas/rt-infra/etc/org.talend.ipaas.rt.notification.subscription.service.cfg') do
-    its(:content) { should include 'memcached.connectionString = my-memcached-host:my-memcached-port' }
-git     its(:content) { should include 'db.redis.host = localhost' }
+    its(:content) { should include 'db.redis.host = localhost' }
     its(:content) { should include 'db.redis.port = 6379' }
   end
 
@@ -90,7 +89,7 @@ git     its(:content) { should include 'db.redis.host = localhost' }
   end
 
   describe file('/opt/talend/ipaas/rt-infra/etc/org.talend.ipaas.rt.liveupdates.kafka.cfg') do
-    its(:content) { should include 'live.updates.kafka.hosts = localhost:9999' }
+    its(:content) { should include 'live.updates.kafka.hosts = localhost:9092' }
   end
 
   describe file('/opt/talend/ipaas/rt-infra/etc/org.talend.ipaas.rt.webhooks.client.cfg') do


### PR DESCRIPTION
https://jira.talendforge.org/browse/DEVOPS-8808
1. Add webhooks_datasource configuration
2. Fix Service test

Test result is
```
services
  Package "talend-ipaas-rt-infra"
    should be installed
  Command "/opt/talend/ipaas/rt-infra/bin/shell "wrapper:install --help""
    stdout
      should include "Install the container as a system service in the OS"
  Service "karaf"
    should be enabled
    should be running under systemd
  Service configuration
    should match /wrapper.jvm_kill.delay\s*=\s*5/
    should match /wrapper.java.additional.10\s*=\s*-XX:MaxMetaspaceSize=256m/
    should match /wrapper.java.additional.11\s*=\s*-Dcom.sun.management.jmxremote.port=7199/
    should match /wrapper.java.additional.12\s*=\s*-Dcom.sun.management.jmxremote.authenticate=false/
    should match /wrapper.java.additional.13\s*=\s*-Dcom.sun.management.jmxremote.ssl=false/
    should match /wrapper.java.maxmemory\s*=\s*1024/
    should match /wrapper.disable_restarts\s*=\s*true/
  File "/opt/talend/ipaas/rt-infra/etc/org.talend.ipaas.rt.eventsource.amq.cfg"
    content
      should include "activemq.broker.password=activemq_broker_test_password"
  File "/opt/talend/ipaas/rt-infra/etc/org.talend.ipaas.rt.eventsource.amq.cfg"
    content
      should include "activemq.broker.username=activemq_broker_test_username"
  File "/opt/talend/ipaas/rt-infra/etc/org.talend.ipaas.rt.ams.core.cfg"
    content
      should match /amq_security\s*=\s*false/
  File "/opt/talend/ipaas/rt-infra/etc/org.talend.ipaas.rt.pe.client.cfg"
    content
      should include "pe.service.username=pe_service_test_username"
    content
      should include "pe.service.password=missing"
  File "/opt/talend/ipaas/rt-infra/etc/org.talend.ipaas.rt.flowmanager.cfg"
    content
      should include "time.to.unknown=999"
  File "/opt/talend/ipaas/rt-infra/etc/quartz.properties"
    content
      should match /org.quartz.scheduler.instanceId\s*=\s*my-instance-id/
    content
      should match /org.quartz.jobStore.isClustered\s*=\s*false/
    content
      should match /org.quartz.jobStore.clusterCheckinInterval\s*=\s*777/
  File "/opt/talend/ipaas/rt-infra/etc/org.talend.ipaas.rt.dispatcher.nodemanager.aws.cfg"
    content
      should include "\"t_environment\": \"test_env\""
  File "/opt/talend/ipaas/rt-infra/etc/org.ops4j.pax.web.cfg"
    content
      should include "org.osgi.service.http.port=8282"
  File "/opt/talend/ipaas/rt-infra/etc/org.talend.ipaas.rt.lts.client.cfg"
    content
      should include "log.transfer.admin.url=logs_admin_url"
    content
      should include "log.transfer.admin.username=logs_admin_username"
    content
      should include "log.transfer.admin.password=logs_admin_password"
    content
      should include "log.transfer.upload.url=logs_upload_url"
  File "/opt/talend/ipaas/rt-infra/etc/org.talend.ipaas.rt.iam.scim.client.cfg"
    content
      should include "iam-test-url"
    content
      should include "http://scim-test-node"
  File "/opt/talend/ipaas/rt-infra/etc/org.talend.ipaas.rt.bookkeeper.zk.backend.cfg"
    content
      should include "zk.path=/zookeeper/path/prefix"
  File "/opt/talend/ipaas/rt-infra/etc/org.talend.ipaas.rt.notification.subscription.service.cfg"
    content
      should include "db.redis.host = localhost"
    content
      should include "db.redis.port = 6379"
  File "/opt/talend/ipaas/rt-infra/etc/org.talend.ipaas.rt.zipkin.cfg"
    content
      should include "zipkin.enabled = true"
    content
      should include "zipkin.kafka.topic = zipkin"
    content
      should include "zipkin.kafka.bootstrapServers = localhost:9999"
    content
      should include "zipkin.sampler.percentage = 0.3"
  File "/opt/talend/ipaas/rt-infra/etc/org.talend.ipaas.rt.liveupdates.kafka.cfg"
    content
      should include "live.updates.kafka.hosts = localhost:9092"
  File "/opt/talend/ipaas/rt-infra/etc/org.talend.ipaas.rt.webhooks.client.cfg"
    content
      should include "webhooks.service.url=webhook-url-for-client"
  File "/opt/talend/ipaas/rt-infra/etc/org.talend.ipaas.rt.cms.cfg"
    content
      should include "license-management.url = http://license-management-node"
    content
      should include "vault.ipaas.secret.id = somesecret"
    content
      should include "vault.ipaas.role.id = e9d94f22-7ebc-f753-4a00-1520fc4089ce"
  File "/opt/talend/ipaas/rt-infra/bin/karaf.service"
    content
      should not include "WantedBy=default.target"
  File "/opt/talend/ipaas/rt-infra/etc/org.talend.ipaas.rt.eventsource.kafka.cfg"
    content
      should include "provisioning.apps.kafka.hosts = localhost:9092"
    content
      should include "provisioning.apps.kafka.topic = provisioning"
    content
      should include "log.messages = true"
  File "/opt/talend/ipaas/rt-infra/etc/org.talend.ipaas.rt.dispatcher.core.cfg"
    content
      should include "db.host = dispatcher-redis"
    content
      should include "db.port = 1234"
    content
      should include "kafka.apps.hosts = localhost:9092"
    content
      should include "kafka.apps.topic = app-to-runtime"
    content
      should include "kafka.statuses.hosts = localhost:9092"
    content
      should include "kafka.statuses.topic = events-to-platform"

Finished in 3.81 seconds (files took 0.62193 seconds to load)
50 examples, 0 failures

       Finished verifying <services-centos-75> (0m5.41s).
-----> Destroying <services-centos-75>...
       ==> default: Forcing shutdown of VM...
       ==> default: Destroying VM and associated drives...
       ==> default: Pruning invalid NFS exports. Administrator privileges will be required...
       sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper
       Vagrant instance <services-centos-75> destroyed.
       Finished destroying <services-centos-75> (0m6.17s).
       Finished testing <services-centos-75> (2m59.68s).
-----> Kitchen is finished. (3m0.23s)

```